### PR TITLE
Add "load / save canvas" functions

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,12 +259,20 @@
 						</div> -->
 
 						<div class="sidebar__section">
+							<button id="save-canvas" class="btn btn-primary btn-block">
+								Save Playground
+							</button>
+							<button id="load-canvas" class="btn btn-primary btn-block">
+								Load Playground
+							</button>
+						</div>
+
+						<div class="sidebar__section">
 							<button id="clear-canvas" class="btn-reset text-danger" data-toggle="modal" data-target="#clear-canvas-modal">
 								<span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
 								Reset Playground
 							</button>
 						</div>
-
 
 					</div>
 					<!-- sidebar__scroll -->

--- a/index.html
+++ b/index.html
@@ -259,15 +259,6 @@
 						</div> -->
 
 						<div class="sidebar__section">
-							<button id="save-canvas" class="btn btn-primary btn-block">
-								Save Playground
-							</button>
-							<button id="load-canvas" class="btn btn-primary btn-block">
-								Load Playground
-							</button>
-						</div>
-
-						<div class="sidebar__section">
 							<button id="clear-canvas" class="btn-reset text-danger" data-toggle="modal" data-target="#clear-canvas-modal">
 								<span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
 								Reset Playground
@@ -297,6 +288,15 @@
 				<div class="panel__action">
 					<label for="canvas-scale">Canvas scale</label>
 					<input class="form-control input-sm" id="canvas-scale" type="number" value="25" />
+				</div>
+
+				<div class="panel__action" style="flex-direction: column;">
+					<button id="save-canvas" class="btn btn-default btn-block">
+						Save to File
+					</button>
+					<button id="load-canvas" class="btn btn-default btn-block">
+						Import from File
+					</button>
 				</div>
 			</div>
 		</div>

--- a/public/scripts/scripts.js
+++ b/public/scripts/scripts.js
@@ -115,6 +115,15 @@ $(document).ready(function () {
 		e.preventDefault();
 	});
 
+	$("body").on("click", "#save-canvas", function (e) {
+		downloadPedalCanvas("canvas.json");
+	});
+
+	$("body").on("click", "#load-canvas", function (e) {
+		uploadPedalCanvas();
+		savePedalCanvas();
+	});
+
 	$("body").on("click", "#clear-canvas-confirmation", function () {
 		$(".canvas").empty();
 		$("#clear-canvas-modal").modal("hide");
@@ -500,6 +509,67 @@ function readyCanvas() {
 function savePedalCanvas() {
 	console.log("Canvas Saved!");
 	localStorage["pedalCanvas"] = JSON.stringify($(".canvas").html());
+}
+
+function exportPedalCanvas() {
+	return new Blob(
+		[ JSON.stringify(
+			{
+				source: "pedalplayground.com",
+				version: "1.0",
+				canvas: JSON.parse(localStorage["pedalCanvas"])
+			}
+		)],
+		{ type: "application/json" }
+	);
+}
+
+function downloadPedalCanvas(filename) {
+	console.log("Downloading canvas to " + filename);
+
+	const blob = exportPedalCanvas();
+
+	const url = window.URL.createObjectURL(blob);
+
+	const a = document.createElement("a");
+	a.style.display = "none";
+	a.href = url;
+	a.download = filename;
+	document.body.appendChild(a);
+	a.click();
+
+	window.URL.revokeObjectURL(url);
+}
+
+function importPedalCanvas(file) {
+	console.log("Importing canvas from " + file);
+
+	var reader = new FileReader();
+
+	reader.addEventListener(
+		"load",
+		() => {
+			blob = JSON.parse(reader.result);
+
+			// TODO: check source and version
+			
+			$(".canvas").html(blob.canvas);
+		},
+		false,
+	);
+
+	reader.readAsText(file);
+}
+
+function uploadPedalCanvas() {
+	console.log("Uploading canvas ...");
+	var input = document.createElement("input");
+	input.type = 'file';
+	input.onchange = _ => {
+		var file = input.files[0];
+		importPedalCanvas(file);
+	};
+	input.click();
 }
 
 function rotatePedal(pedal) {

--- a/public/scripts/scripts.js
+++ b/public/scripts/scripts.js
@@ -116,12 +116,15 @@ $(document).ready(function () {
 	});
 
 	$("body").on("click", "#save-canvas", function (e) {
-		downloadPedalCanvas("canvas.json");
+		const currentDate = new Date().toLocaleDateString() + new Date().toLocaleTimeString();
+
+		downloadPedalCanvas("Pedal Playground - " + currentDate + ".json");
 	});
 
 	$("body").on("click", "#load-canvas", function (e) {
 		uploadPedalCanvas();
 		savePedalCanvas();
+		readyCanvas();
 	});
 
 	$("body").on("click", "#clear-canvas-confirmation", function () {
@@ -285,7 +288,7 @@ $(document).ready(function () {
 		} else if (height == "") {
 			$("#add-custom-pedal .custom-height").addClass("invalid").focus();
 		} else {
-			console.log("add custom pedal...");
+			//console.log("add custom pedal...");
 			$(".canvas").append(pedal);
 			readyCanvas();
 			// console.log(dims);
@@ -315,7 +318,7 @@ $(document).ready(function () {
 		} else if (height == "") {
 			$("#add-custom-pedalboard .custom-height").addClass("invalid").focus();
 		} else {
-			console.log("add custom pedalboard...");
+			//console.log("add custom pedalboard...");
 			var dims = width + '" x ' + height + '"';
 			var pedalboard =
 				'<div id="item-' +
@@ -458,6 +461,8 @@ function convertIn(value) {
 }
 
 function readyCanvas() {
+	//console.log("canvas ready!");
+
 	var $draggable = $(".canvas .pedal, .canvas .pedalboard").draggabilly({
 		containment: ".canvas",
 	});
@@ -467,7 +472,7 @@ function readyCanvas() {
 	});
 
 	$draggable.on("dragEnd", function (e) {
-		console.log("dragEnd");
+		//console.log("dragEnd");
 		ga("send", "event", "Canvas", "moved", "dragend");
 		savePedalCanvas();
 	});
@@ -507,8 +512,9 @@ function readyCanvas() {
 }
 
 function savePedalCanvas() {
-	console.log("Canvas Saved!");
+	//console.log("Canvas Saved!");
 	localStorage["pedalCanvas"] = JSON.stringify($(".canvas").html());
+	// readyCanvas();
 }
 
 function exportPedalCanvas() {
@@ -525,7 +531,7 @@ function exportPedalCanvas() {
 }
 
 function downloadPedalCanvas(filename) {
-	console.log("Downloading canvas to " + filename);
+	//console.log("Downloading canvas to " + filename);
 
 	const blob = exportPedalCanvas();
 
@@ -542,7 +548,7 @@ function downloadPedalCanvas(filename) {
 }
 
 function importPedalCanvas(file) {
-	console.log("Importing canvas from " + file);
+	//console.log("Importing canvas from " + file);
 
 	var reader = new FileReader();
 
@@ -554,6 +560,7 @@ function importPedalCanvas(file) {
 			// TODO: check source and version
 			
 			$(".canvas").html(blob.canvas);
+			readyCanvas();
 		},
 		false,
 	);
@@ -562,7 +569,7 @@ function importPedalCanvas(file) {
 }
 
 function uploadPedalCanvas() {
-	console.log("Uploading canvas ...");
+	//console.log("Uploading canvas ...");
 	var input = document.createElement("input");
 	input.type = 'file';
 	input.onchange = _ => {
@@ -725,7 +732,7 @@ window.GetPedalBoardData = function () {
 					)
 				);
 			}
-			console.log("Pedalboard data loaded");
+			//console.log("Pedalboard data loaded");
 			//Sort brands and pedals alphabetically
 			pedalboards.sort(function (a, b) {
 				if (a.Brand < b.Brand) {


### PR DESCRIPTION
This patch adds the ability to export the contents of the current canvas to a JSON file.  The canvas can later be restored by importing the JSON file.

This feature has a few limitations (due to my limited JS coding skills):

    - The JSON data is saved to a hard-coded filename (canvas.json), rather than
      prompting the user via a "Save as ..." dialog.

    - There is no validation of the input data, beyond the fact that it must be
      successfully parsed as JSON.  The import should check that the data
      matches an expected schema, which ideally should be versioned.

    - After importing the canvas, none of the items can be clicked and dragged.
      However, if another pedal is then added, all of the items on the canvas
      become draggable.